### PR TITLE
修复多选模式下某个子节点没有回显选中

### DIFF
--- a/components/xiaolu-tree/code.js
+++ b/components/xiaolu-tree/code.js
@@ -70,18 +70,16 @@ export default {
 					catchTreeNone,
 					newCheckList
 				} = this
-				if (props.multiple) {
-					if (props.checkStrictly) {
-						this.checkAllChoose();
-					}
-				} else {
-					this.getNodeRoute(catchTreeNone, newCheckList[0][this.keyCode])
-					let arr = this.nodePathArray.reverse()
-					console.log(arr)
-					if (arr.length == 0) return
-					this.tree_stack = tree_stack.concat(arr);
-					this.tree = this.tree_stack[this.tree_stack.length - 1].children;
-				}
+				let index = 0
+				let flag = props.multiple &&  props.checkStrictly
+				flag && (index = newCheckList.length - 1)
+				this.getNodeRoute(catchTreeNone, newCheckList[index][this.keyCode])
+				let arr = this.nodePathArray.reverse()
+				console.log(arr)
+				if (arr.length == 0) return
+				this.tree_stack = tree_stack.concat(arr);
+				this.tree = this.tree_stack[this.tree_stack.length - 1].children;
+				flag && this.checkAllChoose();
 			}
 		},
 		// 点击项目处理


### PR DESCRIPTION
在多选模式下，回显之前选中的数据中发现某个子节点没有选中，原因：checkAllChoose方法比重新赋值tree要先执行，因此checkAllChoose方法中的tree并不是回显的数据，需要将checkAllChoose放到后面去执行。